### PR TITLE
Add in-repo GitHub Actions workflow for PR rap summaries

### DIFF
--- a/.github/workflows/spit-the-diff.yml
+++ b/.github/workflows/spit-the-diff.yml
@@ -1,0 +1,26 @@
+name: spit-the-diff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  rap-summary:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' || github.event.label.name == 'roast-me'
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate PR summary
+        uses: ./
+        with:
+          format: rap
+          model: gpt-4o-mini
+          max_lines: 8
+          tone: friendly
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          github_token: ${{ github.token }}


### PR DESCRIPTION
### Motivation
- Add a workflow to run the action locally on pull request events so the repository automatically posts rap/haiku/roast summaries once `OPENAI_API_KEY` is configured.

### Description
- Add `.github/workflows/spit-the-diff.yml` that runs on `pull_request` events, uses the local action via `uses: ./`, sets defaults (`format: rap`, `model: gpt-4o-mini`, `max_lines: 8`, `tone: friendly`), grants `contents: read` and `pull-requests: write`, and guards label-triggered runs to only react to `roast-me`.

### Testing
- Validated the workflow file with `sed -n '1,220p' .github/workflows/spit-the-diff.yml`, `nl -ba .github/workflows/spit-the-diff.yml`, and `git status --short`, all of which completed successfully and the file was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8e055cb70832eb1d66f48d863ed4b)