### PR TITLE
Fix README haiku example markdown line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ That’s it. Customize format and other options in [Inputs](#inputs).
 
 > 🌸 **Haiku**
 >
-> Old serializer
-> Cookies crumble into dust
+> Old serializer  
+> Cookies crumble into dust  
 > Auth returns to life
 
 **Roast mode** (triggered by the `roast-me` label):


### PR DESCRIPTION
### Motivation

- The haiku example in `README.md` was rendering as a collapsed single paragraph in some Markdown renderers because the first two lines lacked hard line breaks, so the example did not display as a three-line haiku.

### Description

- Add Markdown hard line breaks (two trailing spaces) to the first two haiku lines in `README.md` so each haiku line renders distinctly inside the blockquote.

### Testing

- Verified the modification and file content using `git diff -- README.md` and inspected the updated lines with `nl -ba README.md | sed -n '56,60p'`, both confirming the trailing spaces were added and the haiku lines are separate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7fe7c1f14832e9cc4b5344a8f5b4a)